### PR TITLE
Fix README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ source venv/bin/activate
 ### 2️⃣ Instale as dependências
 
 ```bash
-pip install -r [requirements.txt](http://_vscodecontentref_/0)
+pip install -r requirements.txt
 ```
 
 ### 3️⃣ Configure o `.env`


### PR DESCRIPTION
## Summary
- fix hyperlink under dependency installation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8894c8688332b0de557e07c3c1c7